### PR TITLE
Add ability to get a node's entry and all related fields

### DIFF
--- a/menus/models/Menus_NodeModel.php
+++ b/menus/models/Menus_NodeModel.php
@@ -120,6 +120,29 @@ class Menus_NodeModel extends BaseElementModel
   }
 
   /**
+  * Returns the entry of a node
+  * {{ node.entry.fieldHandle }}
+  *
+  * @return String|null
+  */
+  public function getEntry()
+  {
+    if ($this->linkedEntryId)
+    {
+      $entry = craft()->entries->getEntryById($this->linkedEntryId);
+      if ($entry != null) {
+        return $entry;
+      } else {
+        return null;
+      }
+    }
+    else
+    {
+      return null;
+    }
+  }
+
+  /**
   * Returns the nodes active state
   *
   * @return String|null

--- a/readme.md
+++ b/readme.md
@@ -61,6 +61,7 @@ Each node has the following properties
 * node.url (full url)
 * node.active (returns true if the node or a childnode matches the current url)
 * node.children (any child nodes)
+* node.entry (returns entire node's entry and all attached fields)
 
 
 


### PR DESCRIPTION
You can now use {{ node.entry }} to get all of a linked entry's field
